### PR TITLE
Significantly improved performance of world generation and all world tile operations

### DIFF
--- a/Terraria/Tile.cs
+++ b/Terraria/Tile.cs
@@ -1,334 +1,173 @@
 #define TILE_BITPACK
+//#define TILE_DEBUG
 using System;
 using System.Runtime.InteropServices;
 
 namespace Terraria
 {
-    public class Tile
-    {
-        public bool active
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].active;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].active = value;
-            }
-        }
-        public bool checkingLiquid
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].checkingLiquid;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].checkingLiquid = value;
-            }
-        }
-        public byte frameNumber
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].frameNumber;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].frameNumber = value;
-            }
-        }
-        public short frameX
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].frameX;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].frameX = value;
-            }
-        }
-        public short frameY
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].frameY;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].frameY = value;
-            }
-        }
-        public bool lava
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].lava;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].lava = value;
-            }
-        }
-        public byte liquid
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].liquid;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].liquid = value;
-            }
-        }
-        public byte type
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].type;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].type = value;
-            }
-        }
-        public byte wall
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].wall;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].wall = value;
-            }
-        }
-        public bool skipLiquid
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].skipLiquid;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].skipLiquid = value;
-            }
-        }
-        public bool lighted
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y].lighted;
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y].lighted = value;
-            }
-        }
-        public bool wire
-        {
-            get { return this.Tiles.Datas[this.X, this.Y].wire; }
-            set { this.Tiles.Datas[this.X, this.Y].wire = value; }
-        }
-        public byte wallFrameNumber
-        {
-            get { return this.Tiles.Datas[this.X, this.Y].wallFrameNumber; }
-            set { this.Tiles.Datas[this.X, this.Y].wallFrameNumber = value; }
-        }
-        public byte wallFrameX
-        {
-            get { return this.Tiles.Datas[this.X, this.Y].wallFrameX; }
-            set { this.Tiles.Datas[this.X, this.Y].wallFrameX = value; }
-        }
-        public byte wallFrameY
-        {
-            get { return this.Tiles.Datas[this.X, this.Y].wallFrameY; }
-            set { this.Tiles.Datas[this.X, this.Y].wallFrameY = value; }
-        }
-        private readonly TileCollection Tiles;
-        private readonly int X;
-        private readonly int Y;
-        public TileData Data
-        {
-            get
-            {
-                return this.Tiles.Datas[this.X, this.Y];
-            }
-            set
-            {
-                this.Tiles.Datas[this.X, this.Y] = value;
-            }
-        }
-        public Tile(TileCollection tiles, int x, int y)
-        {
-            this.Tiles = tiles;
-            this.X = x;
-            this.Y = y;
-        }
-        public object Clone()
-        {
-            return base.MemberwiseClone();
-        }
-        public bool isTheSameAs(Tile compTile)
-        {
-            if (this.active != compTile.active)
-            {
-                return false;
-            }
-            if (this.active)
-            {
-                if (this.type != compTile.type)
-                {
-                    return false;
-                }
-                if (Main.tileFrameImportant[(int)this.type])
-                {
-                    if (this.frameX != compTile.frameX)
-                    {
-                        return false;
-                    }
-                    if (this.frameY != compTile.frameY)
-                    {
-                        return false;
-                    }
-                }
-            }
-            return this.wall == compTile.wall && this.liquid == compTile.liquid && this.lava == compTile.lava && this.wire == compTile.wire;
-        }
-    }
-
-    public class TileCollection
-    {
-        internal TileData[,] Datas;
-        public Tile this[int x, int y]
-        {
-            get
-            {
-                return new Tile(this, x, y);
-            }
-        }
-        internal void SetSize(int x, int y)
-        {
-            this.Datas = new TileData[x, y];
-        }
-    }
-
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public struct TileData
-    {
-        public byte liquid;
-        public byte type;
-        public byte wall;
-        public byte wallFrameNumber;
-        public byte wallFrameX;
-        public byte wallFrameY;
-        public short frameX;
-        public short frameY;
+	public sealed class Tile
+	{
+		public byte liquid;
+		public byte type;
+		public byte wall;
+		public byte wallFrameNumber;
+		public byte wallFrameX;
+		public byte wallFrameY;
+		public short frameX;
+		public short frameY;
 
 #if TILE_BITPACK
-        public bool active
-        {
-            get { return (byte) (this.Flags & TileFlag.Active) != 0; }
-            set { this.SetFlag(TileFlag.Active, value); }
-        }
+		public TileFlag Flags;
 
-        public bool checkingLiquid
-        {
-            get { return (byte) (this.Flags & TileFlag.CheckingLiquid) != 0; }
-            set { this.SetFlag(TileFlag.CheckingLiquid, value); }
-        }
+		public bool active
+		{
+			get { return (byte)(Flags & TileFlag.Active) != 0; }
+			set { this.SetFlag(TileFlag.Active, value); }
+		}
 
-        public byte frameNumber
-        {
-            get { return (byte) (this.Flags & (TileFlag) 3); }
-            set { this.Flags = ((this.Flags & (TileFlag) 252) | (TileFlag) value); }
-        }
+		public bool checkingLiquid
+		{
+			get { return (byte)(Flags & TileFlag.CheckingLiquid) != 0; }
+			set { this.SetFlag(TileFlag.CheckingLiquid, value); }
+		}
 
-        //Perhaps this is causing statue/mannequin issues.
-        /*
-        public short frameX
-        {
-            get
-            {
-                int num = this.frame >> 8;
-                return (short) ((num != 255) ? ((short) (num << 1)) : -1);
-            }
-            set { this.frame = (ushort) (value >> 1 << 8 | (int) (this.frame & 255)); }
-        }
+		public byte frameNumber
+		{
+			get { return (byte)(Flags & (TileFlag)3); }
+			set { Flags = ((Flags & (TileFlag)252) | (TileFlag)value); }
+		}
 
-        public short frameY
-        {
-            get
-            {
-                int num = (int) (this.frame & 255);
-                return (short) ((num != 255) ? ((short) (num << 1)) : -1);
-            }
-            set { this.frame = (ushort) (value >> 1 | (int) (this.frame & 65280)); }
-        }*/
+		public bool lava
+		{
+			get { return (byte)(Flags & TileFlag.Lava) != 0; }
+			set { this.SetFlag(TileFlag.Lava, value); }
+		}
 
-        public bool lava
-        {
-            get { return (byte) (this.Flags & TileFlag.Lava) != 0; }
-            set { this.SetFlag(TileFlag.Lava, value); }
-        }
+		public bool lighted
+		{
+			get { return (byte)(Flags & TileFlag.Lighted) != 0; }
+			set { this.SetFlag(TileFlag.Lighted, value); }
+		}
 
-        public bool lighted
-        {
-            get { return (byte) (this.Flags & TileFlag.Lighted) != 0; }
-            set { this.SetFlag(TileFlag.Lighted, value); }
-        }
+		public bool skipLiquid
+		{
+			get { return (byte)(Flags & TileFlag.SkipLiquid) != 0; }
+			set { this.SetFlag(TileFlag.SkipLiquid, value); }
+		}
 
-        public bool skipLiquid
-        {
-            get { return (byte) (this.Flags & TileFlag.SkipLiquid) != 0; }
-            set { this.SetFlag(TileFlag.SkipLiquid, value); }
-        }
+		public bool wire
+		{
+			get { return (byte)(Flags & TileFlag.Wire) != 0; }
+			set { this.SetFlag(TileFlag.Wire, value); }
+		}
 
-        public bool wire
-        {
-            get { return (byte) (this.Flags & TileFlag.Wire) != 0; }
-            set { this.SetFlag(TileFlag.Wire, value); }
-        }
-
-        private void SetFlag(TileFlag flag, bool set)
-        {
-            if (set)
-            {
-                this.Flags |= flag;
-                return;
-            }
-            this.Flags &= ~flag;
-        }
-
-        private TileFlag Flags;
-        //private ushort frame;
+		private void SetFlag(TileFlag flag, bool set)
+		{
+			if (set)
+				Flags |= flag;
+			else
+				Flags &= ~flag;
+		}
 #else
-
-        public bool active;
-        public bool checkingLiquid;
-        public byte frameNumber;
-        public short frameX;
-        public short frameY;
-        public bool lava;
-        public bool lighted;
-        public bool skipLiquid;
-        public bool wire;
+		public byte frameNumber;
+		public bool active;
+		public bool checkingLiquid;
+		public bool lava;
+		public bool lighted;
+		public bool skipLiquid;
+		public bool wire;
+		public short frameX;
+		public short frameY;
 #endif
-    }
+		public bool isTheSameAs(Tile compTile)
+		{
+			if (this.active != compTile.active)
+			{
+				return false;
+			}
+			if (this.active)
+			{
+				if (type != compTile.type)
+				{
+					return false;
+				}
+				if (Main.tileFrameImportant[(int)type])
+				{
+					if (frameX != compTile.frameX || frameY != compTile.frameY)
+					{
+						return false;
+					}
+				}
+			}
+			return wall == compTile.wall && liquid == compTile.liquid && this.lava == compTile.lava && this.wire == compTile.wire;
+		}
+	}
 
-    public enum TileFlag : byte
-    {
-        Unknown,
-        Reserved1,
-        Wire = 4,
-        Active = 8,
-        SkipLiquid = 16,
-        Lighted = 32,
-        CheckingLiquid = 64,
-        Lava = 128
-    }
+	public class TileCollection
+	{
+		static Tile[] tiles;
+		static int x;
+		static int y;
+#if TILE_DEBUG
+		static int Count = 0;
+		static int AccessCount = 0;
+		public string status
+		{
+			get { return string.Format("Status: {0} elements, {1} accesses, {2}x{3} = {4} => {5}%", Count, AccessCount, x, y, x*y, Count / ((x*y) / 100)); }
+		}
+#else
+		public readonly string status = string.Empty;
+#endif
+
+		public void clear(int x, int y)
+		{
+			tiles[x * TileCollection.y + y] = null;
+		}
+
+		public void reset()
+		{
+			tiles = new Tile[x * y + y];
+		}
+
+		public Tile this[int x, int y]
+		{
+			get
+			{
+#if TILE_DEBUG
+				AccessCount++;
+#endif
+				int idx = x * TileCollection.y + y;
+				Tile tile = tiles[idx];
+				if (null == tile)
+				{
+					tile = new Tile();
+					tiles[idx] = tile;
+#if TILE_DEBUG
+					Count++;
+#endif
+				}
+				return tile;
+			}
+		}
+		internal void SetSize(int x, int y)
+		{
+			TileCollection.x = x;
+			TileCollection.y = y;
+			tiles = new Tile[x * y + y];
+		}
+	}
+
+	public enum TileFlag : byte
+	{
+		Unknown,
+		Reserved1,
+		Wire = 4,
+		Active = 8,
+		SkipLiquid = 16,
+		Lighted = 32,
+		CheckingLiquid = 64,
+		Lava = 128
+	}
 }
 /*using System;
 namespace Terraria

--- a/Terraria/WorldGen.cs
+++ b/Terraria/WorldGen.cs
@@ -929,8 +929,8 @@ namespace Terraria
 							Console.WriteLine("Load failed!  No backup found.");
 							return;
 						}
-						File.Copy(Main.worldPathName + ".bak", Main.worldPathName, true);
-						File.Delete(Main.worldPathName + ".bak");
+						File.Delete(Main.worldPathName);
+						File.Move(Main.worldPathName + ".bak", Main.worldPathName);
 						WorldGen.loadWorld();
 						if (WorldGen.loadFailed || !WorldGen.loadSuccess)
 						{
@@ -1011,8 +1011,8 @@ namespace Terraria
 							Console.WriteLine("Load failed!  No backup found.");
 							return;
 						}
-						File.Copy(Main.worldPathName + ".bak", Main.worldPathName, true);
-						File.Delete(Main.worldPathName + ".bak");
+						File.Delete(Main.worldPathName);
+						File.Move(Main.worldPathName + ".bak", Main.worldPathName);
 						WorldGen.loadWorld();
 						if (WorldGen.loadFailed || !WorldGen.loadSuccess)
 						{
@@ -1079,7 +1079,7 @@ namespace Terraria
 			WorldGen.noLiquidCheck = false;
 			Liquid.numLiquid = 0;
 			LiquidBuffer.numLiquidBuffer = 0;
-            Main.tile.SetSize(Main.maxTilesX + 10, Main.maxTilesY + 10);
+			Main.tile.SetSize(Main.maxTilesX + 1, Main.maxTilesY + 1);
 			if (Main.netMode == 1 || WorldGen.lastMaxTilesX > Main.maxTilesX || WorldGen.lastMaxTilesY > Main.maxTilesY)
 			{
 				for (int i = 0; i < WorldGen.lastMaxTilesX; i++)
@@ -1088,7 +1088,7 @@ namespace Terraria
 					Main.statusText = "Freeing unused resources: " + (int)(num * 100f + 1f) + "%";
 					for (int j = 0; j < WorldGen.lastMaxTilesY; j++)
 					{
-						Main.tile[i, j].Data = new TileData();
+						Main.tile.clear(i, j);
 					}
 				}
 			}
@@ -1096,15 +1096,7 @@ namespace Terraria
 			WorldGen.lastMaxTilesY = Main.maxTilesY;
 			if (Main.netMode != 1)
 			{
-				for (int k = 0; k < Main.maxTilesX; k++)
-				{
-					float num2 = (float)k / (float)Main.maxTilesX;
-					Main.statusText = "Resetting game objects: " + (int)(num2 * 100f + 1f) + "%";
-					for (int l = 0; l < Main.maxTilesY; l++)
-					{
-
-					}
-				}
+				Main.tile.reset();
 			}
 			for (int m = 0; m < 2000; m++)
 			{
@@ -1250,7 +1242,7 @@ namespace Terraria
                                         NetMessage.SendData(17, -1, -1, "", 0, (float) i, (float) j, 0f, 0);
                                     }
                                 }
-                                TileData tiledata = Main.tile[i, j].Data;
+                                Tile tiledata = Main.tile[i, j];
                                 resource_0.Write(tiledata.active);
                                 if (tiledata.active)
                                 {
@@ -1365,10 +1357,10 @@ namespace Terraria
                         {
                             Main.statusText = Lang.gen[50];
                             string local_17 = Main.worldPathName + ".bak";
-                            File.Copy(Main.worldPathName, local_17, true);
+                            File.Delete(local_17);
+                            File.Move(Main.worldPathName, local_17);
                         }
-                        File.Copy(local_2, Main.worldPathName, true);
-                        File.Delete(local_2);
+                        File.Move(local_2, Main.worldPathName);
                     }
                 }
                 WorldGen.saveLock = false;
@@ -2005,6 +1997,7 @@ namespace Terraria
 		}
 		public static void generateWorld(int seed = -1)
 		{
+			DateTime start = DateTime.Now;
 			Main.checkXMas();
 			NPC.clrNames();
 			NPC.setNames();
@@ -4696,6 +4689,10 @@ namespace Terraria
 				num335++;
 			}
 			WorldGen.gen = false;
+			string tileStatus = Main.tile.status;
+			if (!string.IsNullOrEmpty(tileStatus))
+				Console.WriteLine(tileStatus);
+			Console.WriteLine(string.Format("World Generation took {0} seconds", (DateTime.Now - start).TotalSeconds));
 		}
 		public static bool GrowEpicTree(int i, int y)
 		{


### PR DESCRIPTION
While this does increase memory usage the trade off is well worth it given memory is cheep.

Tests on using a small map on a 2.4Ghz Core2 show:-
- Memory usage increased from ~190MB to ~200MB where retail is ~380MB
- World Generation down from ~80 seconds to ~35 seconds where retail is ~20 seconds

TileCollection stats can be enabled by the TILE_DEBUG #define

It may be interesting to note that this should also work without the removal of the
new Tile() assigns in the core code, in fact in theory it should make it even quicker
as the conditional test on the array indexer would be in needed. This could make
updates of future releases easier by reducing the changeset significantly.

Changed world file operations from copies to move's which eliminates unnecessary disk
thrashing for world save and backups
