### PR TITLE
Fixed issue with Snowman Cannon acting odd.

### DIFF
--- a/Terraria/Item.cs
+++ b/Terraria/Item.cs
@@ -28555,6 +28555,7 @@ namespace Terraria
 				this.value = Item.sellPrice(0, 20, 0, 0);
 				this.knockBack = 4f;
 				this.rare = 8;
+				this.explosive = 3;
 				this.ranged = true;
 			}
 			else if (this.type == 1947)


### PR DESCRIPTION
Sets Item.explosive member on the Snowman Cannon so that it doesn't act weird in TShock.
