### PR TITLE
Updates to certain packets

### DIFF
--- a/PacketTypes.cs
+++ b/PacketTypes.cs
@@ -72,6 +72,5 @@ public enum PacketTypes
 	/* 69 */ ChestName,
 	/* 70 */ BugCatching,
 	/* 71 */ BugReleasing,
-	/* 72 */ TravelMerchantItems,
-	/* 73 */ count
+	/* 72 */ TravelMerchantItems
 }


### PR DESCRIPTION
1.2.3 comes with Terraria.ID.MessageIDs which contain a few packets and many named 'unknownx' where x is an integer.
PacketTypes should probably reflect this

Packets changed: 4, 5, 10, 31, 32, 33, 34, 70, 71, 72, 73
Note that this means that TileKill doesn't seem to exist in known packets anymore, and has instead been replaced with 'ChestUpdate'. This could be part of what is causing problems
73 'count' does not seem to be used in the game, but it's in the class so I've added it

If this edit is acceptable, I'll go through the rest of TerrariaAPI-Server and TShock and change the packets to reflect these updated packets where necessary
